### PR TITLE
Remove ms. from links to Azure marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ V2 User Guide : https://docs.microsoft.com/azure/azure-functions/start-stop-vms/
 
 # Global Azure
 
-<a href="https://ms.portal.azure.com/#create/microsoftcorporation1620879115842.startstopv2startstopv2-08252021" target="_blank">
+<a href="https://portal.azure.com/#create/microsoftcorporation1620879115842.startstopv2startstopv2-08252021" target="_blank">
   <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/>
 </a>
 
@@ -16,7 +16,7 @@ V2 User Guide : https://docs.microsoft.com/azure/azure-functions/start-stop-vms/
  
  Customers who have already deployed our Start/Stop V2 solution from the marketplace can use the below link to get the latest version. Please make sure you pass all the resource names correctly by referring to your existing deployment. This is a **one-time manual effort for existing users** to get the latest version, and from there you can configure the auto-update feature to get the latest version automatically.
 
-[![Deploy to Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://ms.portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fstartstopv2prod.blob.core.windows.net%2Fartifacts%2Fssv2autoupdate.json)
+[![Deploy to Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fstartstopv2prod.blob.core.windows.net%2Fartifacts%2Fssv2autoupdate.json)
 
 <p>
   


### PR DESCRIPTION
Links to ms.portal.azure.com instead of portal.azure.com could prevent users from deploying to their own tenant